### PR TITLE
Add script for Google AdSense

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 <head>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-334590-6"></script>
+  <script data-ad-client="ca-pub-6995432654234930" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Adds script to include ads from Google. Google AdSense needs to review the site with this code added before the next step of ad setup, so I'm using my own account for now to set up and test. We don't think this will cause ads to actually appear yet. Can also be replaced with your own AdSense account if desired. 

This is presented as an alternate option to Asheesh's PR #4 to add the Ko-Fi link.

co-authored-by: Asheesh Laroia <asheesh@asheesh.org>